### PR TITLE
fix: 🐛 deal with OSX handling of IPv4 header length

### DIFF
--- a/src/raw.cc
+++ b/src/raw.cc
@@ -414,7 +414,14 @@ void SocketWrap::HandleIOEvent (int status, int revents) {
 		 ** 0.10 and 0.12.  So, for now, we will just give you the number.
 		 **/
 		char status_str[32];
+#ifdef __APPLE__
+		/** 
+		 * OSX deprecates the use of sprintf
+	     */
+		snprintf(status_str, sizeof(status_str), "%d", status);
+#else
 		sprintf(status_str, "%d", status);
+#endif
 		args[1] = Nan::Error(status_str);
 
 		Nan::Call(Nan::New<String>("emit").ToLocalChecked(), handle(), 1, args);
@@ -575,6 +582,26 @@ NAN_METHOD(SocketWrap::Recv) {
 		uv_ip6_name (&sin6_address, addr, 50);
 	else
 		uv_ip4_name (&sin_address, addr, 50);
+
+#ifdef __APPLE__
+	/*
+	FreeBSD has a bug/feature(?) such that:
+
+	- ip_len does not include the IP header's length.  recvfrom() however
+	  returns the packet's true length.  To get the true ip_len field do:
+	  iphdr->ip_len += iphdr->ip_hl << 2;	
+
+	  This code converts this information 
+	*/
+	if (socket->family_ != AF_INET6) {
+		char *message = (char *)node::Buffer::Data(buffer);
+		int header_len = (message[0] & 0x0F) << 2;
+		long packet_len = message[3] << 8 | message[2] + header_len;
+
+		message[3] = packet_len & 0xFF;
+		message[2] = (packet_len >> 8) & 0xFF;
+	}
+#endif
 	
 	Local<Function> cb = Local<Function>::Cast (info[1]);
 	const unsigned argc = 3;


### PR DESCRIPTION
FreeBSD does weird things to the length field in the IP header of a packet; this change reverts those changes so that there is a consistent experience across platforms

✅ Closes: #60